### PR TITLE
New way of handling notes and corrections

### DIFF
--- a/data/aos/corrected/gloomspite_gitz.txt
+++ b/data/aos/corrected/gloomspite_gitz.txt
@@ -1,2 +1,0 @@
-Snarlboss                                                              || 50 x 25mm (PDF was incorrect but now says "Use model")
-Wolfgit Retinue                                                        || 50 x 25mm (PDF was incorrect but now says "Use model")

--- a/data/aos/corrected/skaven.txt
+++ b/data/aos/corrected/skaven.txt
@@ -1,1 +1,0 @@
-Clawlord on Gnaw-beast                                                 || 75 x 42mm (PDF incorrectly says 90 x 52mm)

--- a/data/aos/corrections.txt
+++ b/data/aos/corrections.txt
@@ -1,2 +1,3 @@
+Clawlord on Gnaw-beast                                                 || 75 x 42mm (PDF incorrectly says 90 x 52mm)
 Lord-Veritant                                                          || 40mm [1], 32mm [1] (PDF does not include the Gryph-crow token)
 Reclusians                                                             || 40mm [3], 25mm [2] (PDF does not include the Memorian tokens)

--- a/data/aos/notes.txt
+++ b/data/aos/notes.txt
@@ -1,0 +1,12 @@
+Frazzlegit Shaman on War-Wheela                                        || Now correct in PDF
+Snarlboss on War-Wheela                                                || Now correct in PDF
+Snarlboss                                                              || 50 x 25mm 
+Wolfgit Retinue                                                        || 50 x 25mm
+Harbinger of Decay                                                     || Now correct in PDF
+Doom-Flayers                                                           || Old one was 60 x 35mm
+Stormvermin                                                            || Old ones were 25mm
+Warp-Grinder                                                           || Old one was 60 x 35mm
+Chaos Sorcerer Lord                                                    || Old one was 32mm
+Prince Vhordrai                                                        || Old one was 130mm
+Wight King on Skeletal Steed                                           || Old one was 75 x 42mm
+The Twistweald                                                         || Now correct in PDF

--- a/data/aos/profiles/gloomspite_gitz.txt
+++ b/data/aos/profiles/gloomspite_gitz.txt
@@ -11,8 +11,9 @@ Trugg, the Troggoth King                                               || 100mm
 Webspinner Shaman                                                      || 25mm
 Webspinner Shaman on Arachnarok Spider                                 || 160mm
 Droggz Da Sunchompa                                                    || 60mm
-Frazzlegit Shaman on War-Wheela                                        || 120 x 92mm (Now correct in PDF)
-Snarlboss on War-Wheela                                                || 120 x 92mm (Now correct in PDF)
+Frazzlegit Shaman on War-Wheela                                        || 120 x 92mm
+Snarlboss on War-Wheela                                                || 120 x 92mm
+Snarlboss                                                              || Use model
 Arachnarok Spider with Flinger                                         || 160mm
 Arachnarok Spider with Spiderfang Warparty                             || 160mm
 Boingrot Bounderz                                                      || 32mm
@@ -31,6 +32,7 @@ Spider Riders                                                          || 60 x 3
 Sporesplatta Fanatics                                                  || 32mm
 Squig Herd                                                             || 25mm
 Squig Hoppers                                                          || 32mm
+Wolfgit Retinue                                                        || Use model
 Sunsteala Wheelas                                                      || 105 x 70mm
 Doom Diver Catapult                                                    || 170 x 105mm
 Snarlpack Cavalry                                                      || 75 x 42mm

--- a/data/aos/profiles/maggotkin_of_nurgle.txt
+++ b/data/aos/profiles/maggotkin_of_nurgle.txt
@@ -8,7 +8,7 @@ Rotmire Creed                                                          || 32mm [
 Bloab Rotspawned                                                       || 100mm
 Great Unclean One                                                      || 130mm
 Gutrot Spume                                                           || 40mm
-Harbinger of Decay                                                     || 90 x 52mm (Now correct in PDF)
+Harbinger of Decay                                                     || 90 x 52mm
 Horticulous Slimux                                                     || 105 x 70mm
 Lord of Afflictions                                                    || 60mm
 Lord of Blights                                                        || 40mm

--- a/data/aos/profiles/skaven.txt
+++ b/data/aos/profiles/skaven.txt
@@ -1,5 +1,6 @@
 Arch-Warlock                                                           || 32mm
 Clawlord                                                               || 32mm
+Clawlord on Gnaw-beast                                                 || 90 x 52mm
 Deathmaster                                                            || 32mm
 Grey Seer                                                              || 32mm
 Grey Seer on Screaming Bell                                            || 120 x 92mm
@@ -19,7 +20,7 @@ Warlock Galvaneer                                                      || 32mm
 Acolyte Globadiers                                                     || 28.5mm
 Brood Terror                                                           || 90mm
 Clanrats                                                               || 25mm
-Doom-Flayers                                                           || 50mm (Old one was 60 x 35mm)
+Doom-Flayers                                                           || 50mm
 Doomwheel                                                              || 105 x 70mm
 Hell Pit Abomination                                                   || 120 x 92mm
 Night Runners                                                          || 25mm
@@ -30,8 +31,8 @@ Rat Ogors                                                              || 50mm
 Ratling Guns                                                           || 60 x 35mm
 Ratling Warpblaster                                                    || 105 x 70mm
 Stormfiends                                                            || 60mm
-Stormvermin                                                            || 28.5mm (Old ones were 25mm)
-Warp-Grinder                                                           || 90 x 52mm (Old one was 60 x 35mm)
+Stormvermin                                                            || 28.5mm
+Warp-Grinder                                                           || 90 x 52mm
 Warp Lightning Cannon                                                  || 120 x 92mm
 Warpfire Throwers                                                      || 60 x 35mm
 Warplock Jezzails                                                      || 60 x 35mm

--- a/data/aos/profiles/slaves_to_darkness.txt
+++ b/data/aos/profiles/slaves_to_darkness.txt
@@ -5,7 +5,7 @@ Centaurion Marshal                                                     || 80mm
 Chaos Lord                                                             || 40mm
 Chaos Lord on Daemonic Mount                                           || 90 x 52mm
 Chaos Lord on Karkadrak                                                || 90 x 52mm
-Chaos Sorcerer Lord                                                    || 40mm (Old one was 32mm)
+Chaos Sorcerer Lord                                                    || 40mm
 Daemon Prince                                                          || 60mm
 Darkoath Chieftain                                                     || 32mm
 Darkoath Chieftain on Warsteed                                         || 75 x 42mm

--- a/data/aos/profiles/soulblight_gravelords.txt
+++ b/data/aos/profiles/soulblight_gravelords.txt
@@ -13,7 +13,7 @@ Mortis Engine                                                          || 120 x 
 Nagash, Supreme Lord of the Undead                                     || 130mm
 Necromancer                                                            || 32mm
 Neferata, Mortarch of Blood                                            || 120 x 92mm
-Prince Vhordrai                                                        || 160mm (Old one was 130mm)
+Prince Vhordrai                                                        || 160mm
 Radukar the Beast                                                      || 60mm
 Radukar the Wolf                                                       || 40mm
 Sekhar, Fang of Nulahmia                                               || 60 x 35mm
@@ -24,7 +24,7 @@ Vampire Lord on Zombie Dragon                                          || 130mm
 Vengorian Lord                                                         || 80mm
 Watch Captain Halgrim                                                  || 32mm
 Wight King                                                             || 32mm
-Wight King on Skeletal Steed                                           || 80mm (Old one was 75 x 42mm)
+Wight King on Skeletal Steed                                           || 80mm
 Wight Lord on Skeletal Steed                                           || 80mm
 Askurgan Trueblades                                                    || 40mm [1], 32mm [4], 28.5mm [3]
 Barrow Guard                                                           || 28.5mm

--- a/data/aos/profiles/stormcast_eternals.txt
+++ b/data/aos/profiles/stormcast_eternals.txt
@@ -33,6 +33,7 @@ Lord-Imperatant                                                        || 40mm [
 Lord-Ordinator                                                         || 40mm
 Lord-Relictor                                                          || 40mm
 Lord-Terminos                                                          || 40mm [1], 25mm [1]
+Lord-Veritant                                                          || 40mm
 Lord-Vigilant on Gryph-stalker                                         || 90 x 52mm
 Lord-Vigilant on Morrgryph                                             || 120 x 92mm
 Iridan the Witness                                                     || 120 x 92mm
@@ -62,6 +63,7 @@ Praetors                                                               || 40mm
 Prosecutors                                                            || 40mm
 Protectors                                                             || 40mm
 Questor Soulsworn                                                      || 40mm
+Reclusians                                                             || 40mm
 Retributors                                                            || 40mm
 Sequitors                                                              || 40mm
 Stormcoven                                                             || 40mm

--- a/data/aos/profiles/sylvaneth.txt
+++ b/data/aos/profiles/sylvaneth.txt
@@ -16,5 +16,5 @@ Kurnoth Hunters with Kurnoth Scythe                                    || 50mm
 Revenant Seekers                                                       || 60mm
 Spite-Revenants                                                        || 32mm
 Spiterider Lancers                                                     || 60mm
-The Twistweald                                                         || 40mm [2], 32mm [3], 28.5mm [3] (Now correct in PDF)
+The Twistweald                                                         || 40mm [2], 32mm [3], 28.5mm [3]
 Tree-Revenants                                                         || 32mm

--- a/data/load.ts
+++ b/data/load.ts
@@ -9,8 +9,21 @@ const splitLine = (line: string): { name: string, size: string } => {
     return { name: parts[0].trim(), size: parts[1].trim() }
 }
 
+const getOverrideData = (file: 'notes' | 'corrections'): Record<string, string> => {
+    const filePath = path.join(dataDirectory, file + '.txt')
+    const fileContents = fs.readFileSync(filePath, 'utf8')
+    const lines = fileContents.split('\n')
+    return lines.reduce((accum, line) => {
+        if (line.length == 0) return accum
+        let { name, size } = splitLine(line)
+        return {...accum, [name]: size}
+    }, {})
+}
+
 const loadWarscrolls = () :TWarscrolls => {
-    const directoryNames: string[] = ['profiles', 'legends', 'unlisted', 'corrected', 'fan-made']
+    const directoryNames: string[] = ['profiles', 'legends', 'unlisted']
+    const notesData: Record<string, string> = getOverrideData('notes')
+    const correctionsData: Record<string, string> = getOverrideData('corrections')
     let warscrolls: TWarscrolls = {}
 
     directoryNames.forEach(directoryName => {
@@ -29,8 +42,9 @@ const loadWarscrolls = () :TWarscrolls => {
                 if (line.length == 0) return warscrolls
 
                 let { name, size } = splitLine(line)
-                let source_override = ''
-                let notes = ''
+                size = correctionsData[name] || size
+                let source_override = correctionsData[name] ? 'corrected' : ''
+                let notes = notesData[name]? "(" + notesData[name] +")" : ''
 
                 const opening_curly_brace_position = size.indexOf('{')
                 const closing_curly_brace_position = size.indexOf('}')

--- a/data/load.ts
+++ b/data/load.ts
@@ -11,7 +11,10 @@ const splitLine = (line: string): { name: string, size: string } => {
 
 const getOverrideData = (file: 'notes' | 'corrections'): Record<string, string> => {
     const filePath = path.join(dataDirectory, file + '.txt')
-    const fileContents = fs.readFileSync(filePath, 'utf8')
+    let fileContents = ''
+    try { fileContents = fs.readFileSync(filePath, 'utf8') }
+    catch(ENOENT) { return {} }
+
     const lines = fileContents.split('\n')
     return lines.reduce((accum, line) => {
         if (line.length == 0) return accum

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -24,6 +24,5 @@ export const aosSources :any = {
     'profiles': 'Battle Profiles April (End) 2025',
     'legends': 'Legends April (End) 2025',
     'unlisted': 'Unlisted',
-    'corrected': 'Corrected',
-    'fan-made': 'Fan-made faction',
+    'corrected': 'Unofficial correction',
 }


### PR DESCRIPTION
Moves my notes (such as for when an official profile was wrong but now isn't, or when a model used to come on a different base size) out of the files which get generated when the official pdf is imported, so that reconciling the import process is much simpler (I will no longer have to go through and specifically retain the notes while accepting any legitimate changes).

Also moves corrections from a dir to a file and lets them stay in the auto-generated files too, again saving some reconciliation effort.